### PR TITLE
Highlight a line of code in the readme, and add a test

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The normal way:
 npm install difference-accumulator
 ```
 
-```
+```node
 const accumulator = require('difference-accumulator')
 ```
 

--- a/test.js
+++ b/test.js
@@ -54,6 +54,7 @@ test('an accumulation of undefined will be part of the delta', t => {
 	acc.accumulate({ firstName: undefined })
 	const diff = acc.difference()
 	t.equal(Object.keys(diff)[0], 'firstName')
+	t.equal(Object.keys(diff).length, 1)
 	t.ok(diff.firstName === undefined)
 	t.end()
 })


### PR DESCRIPTION
These two changes have been sitting on my local disk for a long time. Maybe 2 years.

It uses [`node` highlighting](https://github.com/vesln/jsmd#which-code-blocks-get-evaluated) so the code isn't evaluated by jsmd.